### PR TITLE
fix(release): Fix changelog script edge cases and version consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.9.2] - 2025-09-01
+
+### Fixed
+- Fixed release script edge case where `extractForVersion` could match partial versions (e.g., searching for "0.9" would incorrectly match "0.9.1" or "0.9.0")
+- Fixed backfill mode tag naming inconsistency - now consistently uses "v" prefixed tags for all releases
+- Improved version extraction to use exact matching instead of regex partial matching
+
 ## [0.9.1] - 2025-09-01
 ### Security
 - Fixed XSS/script-breakout vulnerability in PostHog helper by properly escaping JSON before injection into script tags

--- a/__tests__/scripts.test.ts
+++ b/__tests__/scripts.test.ts
@@ -90,7 +90,7 @@ describe("create-release", () => {
 					const u = String(url);
 					const method = opts?.method || "GET";
 					// simulate GET release tag checks
-					if (u.includes("/releases/tags/1.1.0") && method === "GET") {
+					if (u.includes("/releases/tags/v1.1.0") && method === "GET") {
 						return {
 							ok: false,
 							status: 404,
@@ -98,7 +98,7 @@ describe("create-release", () => {
 							text: async () => JSON.stringify({ message: "Not Found" }),
 						};
 					}
-					if (u.includes("/releases/tags/1.0.0") && method === "GET") {
+					if (u.includes("/releases/tags/v1.0.0") && method === "GET") {
 						return {
 							ok: true,
 							status: 200,
@@ -106,7 +106,7 @@ describe("create-release", () => {
 							text: async () => JSON.stringify({ id: 111 }),
 						};
 					}
-					if (u.includes("/releases/tags/0.9.0") && method === "GET") {
+					if (u.includes("/releases/tags/v0.9.0") && method === "GET") {
 						return {
 							ok: true,
 							status: 200,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@contentagen/sdk",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"private": false,
 	"type": "module",
 	"description": "Official TypeScript SDK to interact with the ContentaGen API. Provides lightweight client methods for listing and retrieving content, automatic input validation, date parsing, and robust error handling.",

--- a/scripts/create-release.ts
+++ b/scripts/create-release.ts
@@ -78,7 +78,7 @@ export async function run() {
 		const entries = parseAllVersions(changelog);
 		for (const e of entries) {
 			const ver = e.version;
-			const tagName = ver; // use exact version as tag and name
+			const tagName = `v${ver}`; // use v-prefixed version as tag and name
 			const listUrl = `${GITHUB_API}/repos/${owner}/${repo}/releases/tags/${tagName}`;
 			try {
 				await githubFetch(listUrl, "GET", null, token);

--- a/scripts/extract-changelog.ts
+++ b/scripts/extract-changelog.ts
@@ -11,33 +11,11 @@ export function extractForVersion(
 	version: string,
 ): string | null {
 	if (!changelogText) return null;
-	const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-	const headerRegex = new RegExp(`^##+\\s*\\[?${escaped}\\]?\\b.*$`, "m");
-	const lines = changelogText.split(/\r?\n/);
 
-	let start = -1;
-	let headerLevel = 0;
-	for (let i = 0; i < lines.length; i++) {
-		if (headerRegex.test(lines[i])) {
-			start = i + 1;
-			const m = lines[i].match(/^(#+)/);
-			headerLevel = m ? m[1].length : 2;
-			break;
-		}
-	}
-	if (start === -1) return null;
-
-	let end = lines.length;
-	const nextHeader = new RegExp(`^#{1,${headerLevel}}\\s+`);
-	for (let i = start; i < lines.length; i++) {
-		if (nextHeader.test(lines[i])) {
-			end = i;
-			break;
-		}
-	}
-
-	const block = lines.slice(start, end).join("\n").trim();
-	return block || null;
+	// Use parseAllVersions to get all entries, then find exact match
+	const entries = parseAllVersions(changelogText);
+	const entry = entries.find((e) => e.version === version);
+	return entry ? entry.body : null;
 }
 
 export async function extractVersionFromPackageJson(


### PR DESCRIPTION
- Fix extractForVersion to use exact version matching instead of partial regex matching
- Fix backfill mode to use consistent 'v' prefixed tag names
- Update version to 0.9.2 and add changelog entry
- Update tests to reflect the tag naming consistency fix